### PR TITLE
Use async-load in buster.js with external resources. 

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "async-load",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An extremely miminal asynchronous JavaScript loader",
   "keywords": [ "async", "loader", "js", "amd" ],
   "licenses": [

--- a/load.js
+++ b/load.js
@@ -66,11 +66,18 @@ define( function() {
 			} );
 
 		}
+		if (
+                        typeof first_script === 'undefined' ||
+                        typeof first_script.parentNode === 'undefined') {
+                        var head = document.getElementsByTagName('head')[0];
+                        head.appendChild(el);
+                } else {
+                        /**
+                        * Insert script into DOM, starts download
+                        */
+                	first_script.parentNode.insertBefore( el, first_script );
+                }
 
-		/**
-		 * Insert script into DOM, starts download
-		 */
-		first_script.parentNode.insertBefore( el, first_script );
 	};
 } );
 } )( typeof define == 'function'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "async-load",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An extremely miminal asynchronous JavaScript loader",
   "keywords": [
     "async",


### PR DESCRIPTION
When loading external libraries with async-loader, there seems a error when the loader tries to inject the script code into the header. It tries to inject before the "first_script", which is ok in cases where async-loader is in fact the first script. However, in case of buster.js tests it seems the case that there is nothing in the header (first_script.parentNode). I added a little fix that checks if that node is avail, and if not simply appends the new script to the head by el.appendChild.

Check out the usage at 

Test: 
https://github.com/sebs/jsTemplate/blob/master/tests/JSTemplate.load.js

Usage: 
https://github.com/sebs/jsTemplate/blob/master/JSTemplate.load.js
